### PR TITLE
more test cases for async handling. consoliate cb/promise code

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,81 +1,63 @@
 diff = require("deep-diff").diff
 twinning = ({name, newFn, oldFn, onNewFnError, onDiffs, sync, promises}) -> (args...) ->
-  oldResult = null
-  newResult = null
-
-  oldFinished = false
-  newFinished = false
+  oldErrored = false
   newErrored = false
 
-  findAndHandleDiffs = () ->
-    differences = diff oldResult, newResult
+  findAndHandleDiffs = (oldResult, newResult) ->
+    if oldErrored and newErrored
+      # try to get message out of Error obj
+      differences = diff (oldResult.message || oldResult), (newResult.message || newResult)
+    else
+      differences = diff oldResult, newResult
+
     if differences? and onDiffs?
       onDiffs name, differences
 
-  async = not sync and not promises
+  usingCb = not sync and not promises
 
-  if async
-    [args..., cb] = args
-    oldPartial = (next) -> oldFn args..., next
-    newPartial = (next) -> newFn args..., next
-    onFinish = () ->
-      findAndHandleDiffs()
-      return cb null, oldResult
-
-    oldPartial (err, result) ->
-      if err?
-        return cb err
-      oldFinished = true
-      oldResult = result
-      if newFinished
-        onFinish()
-      else if newErrored
-        return cb null, result
-
-    newPartial (err, result) ->
-      if err?
-        if onNewFnError?
-          onNewFnError name, err
-        newErrored = true
-        if oldFinished
-          return cb null, oldResult
-      else
-        newFinished = true
-        newResult = result
-        if oldFinished
-          onFinish()
-
-  else if promises
+  handleAsync = (oldPromise, newPromise) ->
     return new Promise (resolve, reject) ->
-      oldFn args...
-        .then (result) ->
-          oldFinished = true
-          oldResult = result
-          if newFinished
-            # run diff in next tick so exceptions don't get caught
-            process.nextTick ->
-              findAndHandleDiffs()
-              resolve(oldResult)
-          else if newErrored
-            resolve(oldResult)
+      runningOld = oldPromise
         .catch (err) ->
-          reject(err)
-      newFn args...
-        .then (result) ->
-          newFinished = true
-          newResult = result
-          if oldFinished
-            # run diff in next tick so exceptions don't get caught
-            process.nextTick ->
-              findAndHandleDiffs()
-              resolve(oldResult)
-        .catch (err) ->
-          if onNewFnError?
-            onNewFnError name, err
-          newErrored = true
-          if oldFinished
-            resolve(oldResult)
+          oldErrored = true
+          return err
 
+      runningNew = newPromise
+        .catch (err) ->
+          newErrored = true
+          return err
+
+      Promise.all [runningOld, runningNew]
+        .then ([oldResult, newResult]) ->
+          # only call onNewFnError if only newFn errored
+          if newErrored and not oldErrored
+            if onNewFnError
+              # nextTick so exceptions don't get caught by containing promise
+              process.nextTick ->
+                onNewFnError name, newResult
+          else
+            # nextTick so exceptions don't get caught by containing promise
+            process.nextTick ->
+              findAndHandleDiffs(oldResult, newResult)
+
+          # nextTick resolving so onNewFnError/findAndHandleDiffs get to run first
+          process.nextTick ->
+            if oldErrored
+              reject oldResult
+            else
+              resolve oldResult
+
+  if usingCb
+    [args..., cb] = args
+
+    oldPromise = fromCallback (next) -> oldFn args..., next
+    newPromise = fromCallback (next) -> newFn args..., next
+
+    runningTasks = handleAsync oldPromise, newPromise
+
+    asCallback runningTasks, cb
+  else if promises
+    return handleAsync (oldFn args...), (newFn args...)
   else if sync
     oldResult = oldFn args...
     try
@@ -84,7 +66,7 @@ twinning = ({name, newFn, oldFn, onNewFnError, onDiffs, sync, promises}) -> (arg
       if onNewFnError?
         onNewFnError name, err
       return oldResult
-    findAndHandleDiffs()
+    findAndHandleDiffs(oldResult, newResult)
     return oldResult
 
 module.exports = twinning
@@ -92,3 +74,13 @@ module.exports.defaults = (defaults) -> (params) ->
   for k, v of defaults
     params[k] ?= v
   return twinning params
+
+fromCallback = (fn) ->
+  return new Promise (resolve, reject) ->
+    fn (err, result) ->
+      if err?
+        return reject err
+      resolve result
+
+asCallback = (promise, cb) ->
+  promise.then cb.bind(null, null), cb


### PR DESCRIPTION
added some test cases to ensure the following behavior
- if both `oldFn` and `newFn` error, then `onNewFnError` won't be called, because errors are the expected outcome
- if both `oldFn` and `newFn` error, then their error messages (`Error.message`) will be diffed. If a diff is detected, `onDiffs` will be called

implemented the new functionality and refactored `async` mode to also use `Promise` code
